### PR TITLE
Refatora o UserSelector para corrigir bug de seleção

### DIFF
--- a/frontend/src/pages/TaskCreationPage.tsx
+++ b/frontend/src/pages/TaskCreationPage.tsx
@@ -272,16 +272,16 @@ const TaskCreationPage = () => {
                   <Label htmlFor="responsible">Responsável</Label>
                   <UserSelector
                     users={users}
-                    selectedUserId={selectedResponsibleId}
-                    onUserSelect={setSelectedResponsibleId}
+                    value={selectedResponsibleId}
+                    onChange={setSelectedResponsibleId}
                     filterBySquadIds={squadIdsForFilter}
                     disabled={!selectedSubTypeId || users.length === 0}
                   />
-                   {squadIdsForFilter.length > 0 && (
-                     <p className="text-xs text-muted-foreground">
-                       Mostrando usuários dos squads associados a este subtipo.
-                     </p>
-                   )}
+                  {squadIdsForFilter.length > 0 && (
+                    <p className="text-xs text-muted-foreground">
+                      Mostrando usuários dos squads associados a este subtipo.
+                    </p>
+                  )}
                 </div>
 
                 {/* Descrição */}


### PR DESCRIPTION
O componente UserSelector estava utilizando uma lógica que causava a seleção de todos os usuários da lista ao invés de apenas um.

Esta alteração refatora o componente para utilizar um Popover e Command do shadcn/ui, implementando uma lógica de seleção única e melhorando a experiência do usuário. A página de criação de tarefas foi atualizada para utilizar a nova interface do componente.