### PR TITLE
feat: Add missing fields to task creation payload

### DIFF
--- a/app/api/v1/endpoints/tasks.py
+++ b/app/api/v1/endpoints/tasks.py
@@ -172,7 +172,14 @@ def search_lawsuit(
             status_code=404,
             detail=f"Nenhum processo encontrado para o CNJ: {cnj}"
         )
-    return lawsuit
+
+    # Garantir que o retorno para o frontend seja um JSON explícito
+    # contendo todos os dados necessários.
+    return {
+        "id": lawsuit.get("id"),
+        "identifierNumber": lawsuit.get("identifierNumber"),
+        "responsibleOfficeId": lawsuit.get("responsibleOfficeId")
+    }
 
 @router.post("/create-full-process", summary="Criar Tarefa (Processo Completo)", tags=["Tasks"])
 def create_full_task(

--- a/app/services/legal_one_client.py
+++ b/app/services/legal_one_client.py
@@ -196,7 +196,7 @@ class LegalOneApiClient:
         # OData filter requires strings to be in single quotes
         params = {
             "$filter": f"identifierNumber eq '{cnj_number}'",
-            "$select": "id,identifierNumber",
+            "$select": "id,identifierNumber,responsibleOfficeId",
             "$top": 1
         }
         url = f"{self.base_url}{endpoint}"


### PR DESCRIPTION
This commit fixes a validation error (HTTP 422) that occurred during task creation by ensuring all required fields are sent to the Legal One API.

The following changes were implemented:

- **Frontend (`TaskCreationPage.tsx`):**
  - Added `endDateTime` field to the UI with a default value of 24 hours after the start time.
  - The `task_payload` sent to the backend now includes all required fields:
    - `typeId`: Correctly derived from the selected subtype's `parentTypeId`.
    - `endDateTime`: Captured from the new form field.
    - `status`: Hardcoded to `{ "id": 1 }` (Aberta).
    - `originOfficeId`: Hardcoded to `1`.
    - `responsibleOfficeId`: Sourced from the process details.
    - `isResponsible`, `isExecuter`, `isRequester`: Set to `true`.
  - Added frontend validation to ensure `endDateTime` is after `startDateTime`.

- **Backend (`tasks.py`, `legal_one_client.py`):**
  - The `/search-lawsuit` endpoint now correctly fetches and returns the `responsibleOfficeId` from the Legal One API, making it available to the frontend.