### PR TITLE
feat: Add missing fields to task creation form

### DIFF
--- a/app/api/v1/endpoints/offices.py
+++ b/app/api/v1/endpoints/offices.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from typing import List
+from pydantic import BaseModel
+
+from app.core.dependencies import get_db
+from app.models.legal_one import LegalOneOffice
+
+router = APIRouter()
+
+# --- Pydantic Schema for Office Data ---
+class OfficeResponse(BaseModel):
+    id: int
+    name: str
+    external_id: int
+
+    class Config:
+        orm_mode = True
+
+@router.get("/offices", response_model=List[OfficeResponse], summary="Listar todos os escritórios ativos", tags=["Offices"])
+def get_all_offices(db: Session = Depends(get_db)):
+    """
+    Retorna uma lista de todos os escritórios (Offices) que estão marcados como ativos no sistema.
+    """
+    offices = db.query(LegalOneOffice).filter(LegalOneOffice.is_active == True).order_by(LegalOneOffice.name).all()
+    return offices

--- a/app/api/v1/endpoints/tasks.py
+++ b/app/api/v1/endpoints/tasks.py
@@ -172,11 +172,6 @@ def search_lawsuit(
             status_code=404,
             detail=f"Nenhum processo encontrado para o CNJ: {cnj}"
         )
-<<<<<<< HEAD
-    
-=======
-
->>>>>>> 28a842112154a3314d52aba49b8a0dd8cf92684e
     return lawsuit
 
 @router.post("/create-full-process", summary="Criar Tarefa (Processo Completo)", tags=["Tasks"])

--- a/frontend/src/pages/TaskCreationPage.tsx
+++ b/frontend/src/pages/TaskCreationPage.tsx
@@ -9,6 +9,7 @@ import { Loader2, Search } from 'lucide-react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
+import { Checkbox } from "@/components/ui/checkbox";
 import UserSelector, { SelectableUser } from '@/components/ui/UserSelector'; // Importando o novo componente
 
 // --- Interfaces ---
@@ -30,6 +31,12 @@ interface TaskSubType {
   squad_ids: number[]; // Squads associados a este subtipo
 }
 
+interface Office {
+  id: number;
+  name: string;
+  external_id: number;
+}
+
 const TaskCreationPage = () => {
   const { toast } = useToast();
   const [cnj, setCnj] = useState('');
@@ -41,6 +48,7 @@ const TaskCreationPage = () => {
   const [taskTypes, setTaskTypes] = useState<TaskType[]>([]);
   const [subTypes, setSubTypes] = useState<TaskSubType[]>([]);
   const [users, setUsers] = useState<SelectableUser[]>([]); // Usando a interface do UserSelector
+  const [offices, setOffices] = useState<Office[]>([]);
   const [isFormLoading, setIsFormLoading] = useState(true);
 
   // Estado dos campos do formulário
@@ -49,6 +57,13 @@ const TaskCreationPage = () => {
   const [selectedResponsibleId, setSelectedResponsibleId] = useState<string | null>(null); // Pode ser null
   const [description, setDescription] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Novos estados para os campos faltantes
+  const [selectedStatusId, setSelectedStatusId] = useState<string>('1'); // Default to "Aberta"
+  const [selectedOriginOfficeId, setSelectedOriginOfficeId] = useState<string>('');
+  const [isResponsible, setIsResponsible] = useState(true);
+  const [isExecuter, setIsExecuter] = useState(true);
+  const [isRequester, setIsRequester] = useState(true);
   
   // Novos estados para data
   const [startDateTime, setStartDateTime] = useState(new Date());
@@ -63,14 +78,24 @@ const TaskCreationPage = () => {
     const fetchFormData = async () => {
       setIsFormLoading(true);
       try {
-        const response = await fetch('/api/v1/tasks/task-creation-data');
-        if (!response.ok) {
+        // Usando Promise.all para carregar dados em paralelo
+        const [taskDataResponse, officesResponse] = await Promise.all([
+          fetch('/api/v1/tasks/task-creation-data'),
+          fetch('/api/v1/offices')
+        ]);
+
+        if (!taskDataResponse.ok || !officesResponse.ok) {
           throw new Error('Falha ao carregar os dados necessários para o formulário.');
         }
-        const data = await response.json();
-        setTaskTypes(data.task_types);
-        setSubTypes(data.sub_types);
-        setUsers(data.users);
+
+        const taskData = await taskDataResponse.json();
+        const officesData = await officesResponse.json();
+
+        setTaskTypes(taskData.task_types);
+        setSubTypes(taskData.sub_types);
+        setUsers(taskData.users);
+        setOffices(officesData);
+
       } catch (error) {
         const msg = error instanceof Error ? error.message : 'Erro desconhecido';
         toast({ title: 'Erro ao Carregar Dados', description: msg, variant: 'destructive' });
@@ -115,10 +140,10 @@ const TaskCreationPage = () => {
 
   const handleSubmit = async () => {
     // A validação do Tipo (selectedTaskTypeId) é removida pois o que importa para o payload é o subtipo, que contém o parentId.
-    if (!foundLawsuit || !selectedSubTypeId || !selectedResponsibleId) {
+    if (!foundLawsuit || !selectedSubTypeId || !selectedResponsibleId || !selectedOriginOfficeId) {
       toast({
         title: 'Campos Obrigatórios',
-        description: 'Tipo, subtipo e responsável são obrigatórios.',
+        description: 'Tipo, subtipo, responsável e escritório de origem são obrigatórios.',
         variant: 'destructive',
       });
       return;
@@ -156,21 +181,25 @@ const TaskCreationPage = () => {
       subTypeId: parseInt(selectedSubTypeId, 10),
       description: description || 'Tarefa criada via sistema',
       priority: 'Normal',
-      typeId: selectedSubType.parentTypeId, // Correção: Usar o parentTypeId do subtipo
+      typeId: selectedSubType.parentTypeId,
       startDateTime: startDateTime.toISOString(),
       endDateTime: endDateTime.toISOString(),
-      status: { id: 1 },
-      originOfficeId: 1, // MDR Advocacia
+      status: { id: parseInt(selectedStatusId, 10) },
+      originOfficeId: parseInt(selectedOriginOfficeId, 10),
       responsibleOfficeId: foundLawsuit.responsibleOfficeId,
-      isResponsible: true,
-      isExecuter: true,
-      isRequester: true,
     };
 
     const requestBody = {
       cnj_number: foundLawsuit.identifierNumber,
       task_payload,
-      participants: [], // A definição de papéis agora é feita no payload principal.
+      participants: [
+        {
+          contact_id: parseInt(selectedResponsibleId, 10),
+          is_responsible: isResponsible,
+          is_executer: isExecuter,
+          is_requester: isRequester,
+        }
+      ],
     };
 
     try {
@@ -198,6 +227,11 @@ const TaskCreationPage = () => {
       setSelectedSubTypeId('');
       setSelectedResponsibleId('');
       setDescription('');
+      setSelectedStatusId('1');
+      setSelectedOriginOfficeId('');
+      setIsResponsible(true);
+      setIsExecuter(true);
+      setIsRequester(true);
 
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Ocorreu um erro desconhecido.';
@@ -334,6 +368,75 @@ const TaskCreationPage = () => {
                       Mostrando usuários dos squads associados a este subtipo.
                     </p>
                   )}
+                </div>
+
+                {/* Escritório de Origem e Status */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="origin-office">Escritório de Origem</Label>
+                        <Select value={selectedOriginOfficeId} onValueChange={setSelectedOriginOfficeId} disabled={offices.length === 0}>
+                            <SelectTrigger id="origin-office">
+                                <SelectValue placeholder="Selecione o escritório..." />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {offices.map(office => (
+                                    <SelectItem key={office.id} value={String(office.external_id)}>{office.name}</SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="task-status">Status</Label>
+                        <Select value={selectedStatusId} onValueChange={setSelectedStatusId}>
+                            <SelectTrigger id="task-status">
+                                <SelectValue placeholder="Selecione o status..." />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="1">Aberta</SelectItem>
+                                <SelectItem value="2">Em Andamento</SelectItem>
+                                <SelectItem value="3">Pendente</SelectItem>
+                                <SelectItem value="4">Concluída</SelectItem>
+                                <SelectItem value="5">Cancelada</SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </div>
+
+                {/* Papéis (Flags Booleanas) */}
+                <div className="space-y-2 pt-2">
+                  <Label>Papéis do Usuário na Tarefa</Label>
+                  <div className="flex items-center space-x-6 pt-2">
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="isResponsible"
+                        checked={isResponsible}
+                        onCheckedChange={(checked) => setIsResponsible(Boolean(checked))}
+                      />
+                      <Label htmlFor="isResponsible" className="font-normal leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                        Responsável
+                      </Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="isExecuter"
+                        checked={isExecuter}
+                        onCheckedChange={(checked) => setIsExecuter(Boolean(checked))}
+                      />
+                      <Label htmlFor="isExecuter" className="font-normal leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                        Executor
+                      </Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="isRequester"
+                        checked={isRequester}
+                        onCheckedChange={(checked) => setIsRequester(Boolean(checked))}
+                      />
+                      <Label htmlFor="isRequester" className="font-normal leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                        Solicitante
+                      </Label>
+                    </div>
+                  </div>
                 </div>
 
                 {/* Datas de Início e Fim */}

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 
 from fastapi import FastAPI # type: ignore
 from fastapi.middleware.cors import CORSMiddleware
-from app.api.v1.endpoints import admin, dashboard, tasks, squads, sectors, users
+from app.api.v1.endpoints import admin, dashboard, tasks, squads, sectors, users, offices
 
 app = FastAPI(title="OneTask API", version="1.0.0")
 
@@ -26,6 +26,7 @@ app.include_router(squads.router, prefix="/api/v1/squads", tags=["Squads"])
 app.include_router(sectors.router, prefix="/api/v1/sectors", tags=["Sectors"])
 app.include_router(tasks.router, prefix="/api/v1/tasks", tags=["Tasks"])
 app.include_router(users.router, prefix="/api/v1/users", tags=["Users"])
+app.include_router(offices.router, prefix="/api/v1", tags=["Offices"])
 
 
 # Endpoint Raiz


### PR DESCRIPTION
This commit resolves an issue where the task creation form was missing several fields required by the backend API, preventing successful task creation.

The following changes were made:

- Backend:
  - Created a new endpoint `/api/v1/offices` to provide a list of active offices for the form.
  - Registered the new router in the main FastAPI application.

- Frontend (`TaskCreationPage.tsx`):
  - Added state management and data fetching for offices.
  - Added UI components for the missing fields:
    - "Origin Office" dropdown.
    - "Status" dropdown.
    - Checkboxes for user roles ("Responsible", "Executor", "Solicitante").
  - Updated the form submission logic to include all new fields in the API payload, matching the backend's expected structure.
  - Updated the form reset logic to clear the new fields upon successful submission.

- Fixes:
  - Corrected a `SyntaxError` in `app/api/v1/endpoints/tasks.py` caused by a leftover merge conflict marker.
  - Created the missing `frontend/src/lib/utils.ts` file, which was causing the frontend application to crash on startup.
  - Created a placeholder `.env` file to allow the application to start correctly in the development environment.